### PR TITLE
Add initial prefetch_related for #18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.6.4
 
 - Fix queries joining through multiple tables
+- Add initial implementation of prefetch_related
 
 # 0.6.3
 


### PR DESCRIPTION
Adds an initial implementation of `prefetch_related`.  

It is currently somewhat limited in that:
- It does not support tables with multiple back references
- Can only prefetch one level deep
- Does not have any intelligence to cache prefetches (if that's possible)