### PR TITLE
Use codegen to speed up getstate and restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install -U aiopg 'sqlalchemy<1.4' codecov pytest pytest-coverage pytest-asyncio faker
+        run: pip install -U aiopg 'sqlalchemy<1.4' codecov pytest pytest-benchmark pytest-cov pytest-asyncio faker
       - name: Install atom-db
         run: pip install -e ./
       - name: Run tests
@@ -68,7 +68,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install -U aiomysql 'sqlalchemy<1.4' codecov pytest pytest-coverage pytest-asyncio faker
+        run: pip install -U aiomysql 'sqlalchemy<1.4' codecov pytest pytest-benchmark pytest-cov pytest-asyncio faker
       - name: Install atom-db
         run: pip install -e ./
       - name: Run tests
@@ -96,7 +96,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install -U motor codecov pytest pytest-coverage pytest-asyncio faker
+        run: pip install -U motor codecov pytest pytest-benchmark pytest-cov pytest-asyncio faker
       - name: Install atom-db
         run: pip install -e ./
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install -U aiopg 'sqlalchemy<1.4' codecov pytest pytest-benchmark pytest-cov pytest-asyncio faker
+        run: pip install -U aiopg sqlalchemy codecov pytest pytest-benchmark pytest-cov pytest-asyncio faker
       - name: Install atom-db
         run: pip install -e ./
       - name: Run tests
@@ -68,7 +68,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install -U aiomysql 'sqlalchemy<1.4' codecov pytest pytest-benchmark pytest-cov pytest-asyncio faker
+        run: pip install -U aiomysql sqlalchemy codecov pytest pytest-benchmark pytest-cov pytest-asyncio faker
       - name: Install atom-db
         run: pip install -e ./
       - name: Run tests
@@ -115,7 +115,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install -U motor aiopg aiomysql 'sqlalchemy<1.4' mypy black isort
+        run: pip install -U motor aiopg aiomysql sqlalchemy mypy black isort
       - name: Run checks
         run: |
             mypy atomdb --ignore-missing-imports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install -U aiomysql sqlalchemy codecov pytest pytest-benchmark pytest-cov pytest-asyncio faker
+        run: pip install -U aiomysql 'sqlalchemy<1.4' codecov pytest pytest-benchmark pytest-cov pytest-asyncio faker
       - name: Install atom-db
         run: pip install -e ./
       - name: Run tests

--- a/atomdb/base.py
+++ b/atomdb/base.py
@@ -340,7 +340,7 @@ class ModelSerializer(Atom):
         # so we must update the scope with this reference to handle this
         # before restoring any children
         if scope and "__ref__" in state:
-            scope[state['__ref__']] = obj
+            scope[state["__ref__"]] = obj
 
         # If not restoring from cache update the state
         if created:

--- a/atomdb/base.py
+++ b/atomdb/base.py
@@ -157,7 +157,7 @@ def resolve_member_types(
     if isinstance(types, tuple):
         # Dict may have an member in the types list, so walk the types
         # and resolve all of those.
-        resolved: list[type] = []
+        resolved: ListType[type] = []
         for t in types:
             if isinstance(t, Member):
                 r = resolve_member_types(t, resolve)

--- a/atomdb/base.py
+++ b/atomdb/base.py
@@ -145,6 +145,7 @@ def resolve_member_types(
         will raise an UnresolvableError with the unresolved member.
 
     """
+    # TODO: This should really use the validate mode...
     if hasattr(member, "resolve"):
         if not resolve:
             raise UnresolvableError(member)  # Do not resolve now
@@ -173,6 +174,8 @@ def resolve_member_types(
         # Follow the chain. For example if the member is defined
         # as `List(Tuple(float)))` lookup the types of the nested Tuple().
         return resolve_member_types(types, resolve)
+    if isinstance(types, str):
+        return None  # Custom validation method
     return (types,)
 
 

--- a/atomdb/nosql.py
+++ b/atomdb/nosql.py
@@ -129,8 +129,13 @@ class NoSQLModel(Model):
         pk = state["_id"]
 
         # Check if this is in the cache
-        cache = cls.objects.cache
-        obj = cache.get(pk)
+        if pk is not None:
+            cache = cls.objects.cache
+            obj = cache.get(pk)
+        else:
+            obj = None
+
+        # Restore
         if obj is None:
             # Create and cache it
             obj = cls.__new__(cls)

--- a/atomdb/nosql.py
+++ b/atomdb/nosql.py
@@ -1,13 +1,11 @@
 """
-Copyright (c) 2018-2020, Jairus Martin.
+Copyright (c) 2018-2022, Jairus Martin.
 
 Distributed under the terms of the MIT License.
 
 The full license is in the file LICENSE.text, distributed with this software.
 
 Created on Jun 12, 2018
-
-@author: jrm
 """
 import weakref
 import bson

--- a/atomdb/nosql.py
+++ b/atomdb/nosql.py
@@ -128,8 +128,7 @@ class NoSQLModel(Model):
         use that instead.
         """
         pk = state["_id"]
-
-        if pk is not None:
+        if pk:
             # Check if this is in the cache
             cache = cls.objects.cache
             obj = cache.get(pk)
@@ -140,7 +139,7 @@ class NoSQLModel(Model):
         if obj is None:
             # Create and cache it
             obj = cls.__new__(cls)
-            if pk is not None:
+            if pk:
                 cache[pk] = obj
             restore = True
         else:

--- a/atomdb/nosql.py
+++ b/atomdb/nosql.py
@@ -131,9 +131,9 @@ class NoSQLModel(Model):
         """
         pk = state["_id"]
 
-        cache = cls.objects.cache
         if pk is not None:
             # Check if this is in the cache
+            cache = cls.objects.cache
             obj = cache.get(pk)
         else:
             obj = None

--- a/atomdb/sql.py
+++ b/atomdb/sql.py
@@ -1365,8 +1365,8 @@ class SQLBinding(Atom):
 
 async def get_cached_model(cls: Type[T], pk: Any, state: StateType) -> Optional[T]:
     """Retrieve a model from the cache using the given pk. If the cached
-    cache does not exist attempt to restore it from the state otherwise create
-    a model that has not been loaded.
+    object does not exist attempt to restore it from the state otherwise create
+    a model that has not been loaded and only contains the id.
 
     Parameters
     ----------

--- a/atomdb/sql.py
+++ b/atomdb/sql.py
@@ -66,6 +66,7 @@ from .base import (
     ScopeType,
     StateType,
     find_subclasses,
+    resolve_member_types,
 )
 
 # kwargs reserved for sqlalchemy table columns
@@ -234,29 +235,6 @@ def py_type_to_sql_column(
         f"determined automatically, please specify it manually by tagging it "
         f"with .tag(column=<sqlalchemy column>) or set `store=False`"
     )
-
-
-def resolve_member_types(member: Member) -> Optional[TupleType[type, ...]]:
-    """Determine the type specified on a member to determine ForeignKey
-    relations.
-
-    Parameters
-    ----------
-    member: atom.catom.Member
-        The member to retrieve the type from
-    Returns
-    -------
-    types: Optional[Tuple[Model or object, ..]]
-        The member types.
-
-    """
-    if hasattr(member, "resolve"):
-        types = member.resolve()  # type: ignore
-    else:
-        types = member.validate_mode[-1]
-    if types is None or isinstance(types, tuple):
-        return types
-    return (types,)
 
 
 def resolve_member_column(

--- a/atomdb/sql.py
+++ b/atomdb/sql.py
@@ -1396,10 +1396,6 @@ class SQLMeta(ModelMeta):
             assert m.index not in member_indices
             member_indices.add(m.index)
 
-        # Set the pk name
-        cls.__pk__ = (pk.metadata or {}).get("name", pk.name)
-        cls.__joined_pk__ = f"{cls.__model__}_{cls.__pk__}"
-
         # Set to the sqlalchemy Table
         cls.__table__ = None
 
@@ -1438,9 +1434,15 @@ class SQLMeta(ModelMeta):
             elif getattr(Meta, "abstract", None) is None:
                 Meta.abstract = False
 
+        # Set the pk name
+        cls.__pk__ = (pk.metadata or {}).get("name", pk.name)
+        cls.__joined_pk__ = f"{cls.__model__}_{cls.__pk__}"
+
         # Create a set of fields to remove from state before saving to the db
         # this removes Relation instances and several needed for json
-        excluded_fields = cls.__excluded_fields__ = {"__model__", "__ref__", "_id"}
+        excluded_fields = cls.__excluded_fields__ = {"__model__", "__ref__"}
+        if cls.__pk__ != "_id":
+            excluded_fields.add("_id")
 
         for name, member in cls.members().items():
             if isinstance(member, Relation):

--- a/atomdb/sql.py
+++ b/atomdb/sql.py
@@ -335,13 +335,13 @@ def resolve_relation(
     model: SQLModel
         The model to lookup.
     field: str
-        Path to of a Relation member
+        Path to a Relation member
 
     Returns
     -------
     result: tuple[SQLModel, Member]
         The model this field refers to and the member on that model that is
-        a foreign key to the given model.
+        a foreign key to model.
 
     """
     relation = model.members().get(field)

--- a/makefile
+++ b/makefile
@@ -8,5 +8,6 @@ typecheck:
 
 reformat:
 	black atomdb
+	black tests
 
 precommit: isort reformat typecheck

--- a/setup.py
+++ b/setup.py
@@ -23,10 +23,10 @@ setup(
     long_description_content_type="text/markdown",
     requires=['atom'],
     python_requires='>=3.7',
-    install_requires=['atom>=0.7.0'],
+    install_requires=['atom>=0.7.0', 'bytecode'],
     optional_requires=[
         'sqlalchemy', 'aiomysql', 'aiopg',  'aiosqlite',  # sql database support
-        'motor', 'txmongo'  # nosql database support
+        'motor', # nosql database support
     ],
     packages=find_packages(),
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='atom-db',
-    version='0.6.4',
+    version='0.7.0.dev',
     author='CodeLV',
     author_email='frmdstryr@gmail.com',
     url='https://github.com/codelv/atom-db',

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 from atom.api import *
 from atomdb.base import (
     Model, ModelManager, ModelSerializer,
@@ -22,16 +23,26 @@ class Dummy(Model):
     list_of_int = List(int)
     list_of_str = List(str)
     list_of_any = List()
+    list_of_tuple = List(Tuple())
+    list_of_tuple_of_float = List(Tuple(float))
     tuple_of_any = Tuple()
     tuple_of_number = Tuple((float, int))
     tuple_of_int_or_model = Tuple((int, Model))
+    tuple_of_forwarded = Tuple(ForwardTyped(lambda: NotYetDefined))
     set_of_any = Tuple()
     set_of_number = Set(float)
     set_of_model = Set(AbstractModel)
-    meta = Dict()
+    dict_of_any = Dict()
+    dict_of_str_any = Dict(str)
+    dict_of_str_int = Dict(str, int)
     typed_int = Typed(int)
     typed_dict = Typed(dict)
     instance_of_model = Instance(AbstractModel)
+    forwarded_instance = ForwardInstance(lambda: NotYetDefined)
+
+
+class NotYetDefined:
+    pass
 
 
 @pytest.mark.asyncio
@@ -100,17 +111,72 @@ def test_is_db_field(attr, expected):
     ('list_of_int', True),
     ('list_of_any', False),
     ('list_of_str', True),
+    ('list_of_tuple', False),
+    ('list_of_tuple_of_float', True),
     ('tuple_of_any', False),
     ('tuple_of_number', True),
     ('tuple_of_int_or_model', False),
+    ('tuple_of_forwarded', None),
     ('set_of_any', False),
     ('set_of_number', True),
     ('set_of_model', False),
     ('typed_int', True),
     ('typed_dict', False),
     ('instance_of_model', False),
-    ('meta', False),
+    ('forwarded_instance', None),
+    ('dict_of_any', False),
+    ('dict_of_str_any', False),
+    ('dict_of_str_int', True),
 ))
 def test_is_primitive_member(attr, expected):
     member = Dummy.members()[attr]
     assert is_primitive_member(member) == expected
+
+
+@pytest.mark.asyncio
+async def test_on_error_raise():
+    """ When __on_error__ is raise any old data in the state will make the
+    restore fail.
+    """
+    class A(Model):
+        __on_error__ = 'raise'
+        value = Int()
+
+    with pytest.raises(TypeError):
+        a = await A.restore({"value": "str"})
+
+
+@pytest.mark.asyncio
+async def test_on_error_ignore():
+    """ When __on_error__ is "ignore" and setattr fails the error is discarded
+    """
+    class B(Model):
+        __on_error__ = 'ignore'
+        old_field = Int()
+        new_field = Int()
+
+    b = await B.restore({"old_field": "str", "new_field": 1})
+    assert b.old_field == 0
+    assert b.new_field == 1
+
+
+@pytest.mark.asyncio
+async def test_on_error_log(caplog):
+    """ When __on_error__ is "log" (the default) and setattr fails the error
+    is logged.
+    """
+    class C(Model):
+        old_field = Int()
+        new_field = Int()
+
+    with caplog.at_level(logging.DEBUG):
+        c = await C.restore({"old_field": "str", "new_field": 1})
+        assert c.old_field == 0
+        assert c.new_field == 1
+        assert "Error loading state:" in caplog.text
+        assert f"{C.__model__}.old_field" in caplog.text
+        assert f"object must be of type 'int'" in caplog.text
+
+
+
+

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -43,6 +43,7 @@ class Dummy(Model):
     typed_dict = Typed(dict)
     instance_of_model = Instance(AbstractModel)
     forwarded_instance = ForwardInstance(lambda: NotYetDefined)
+    coerced_int = Coerced(int)
 
 
 class NotYetDefined:
@@ -136,6 +137,7 @@ def test_is_db_field(attr, expected):
         ("dict_of_any", False),
         ("dict_of_str_any", False),
         ("dict_of_str_int", True),
+        ("coerced_int", True),
     ),
 )
 def test_is_primitive_member(attr, expected):

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -49,4 +49,3 @@ def test_restore(benchmark, event_loop):
         event_loop.run_until_complete(Product.restore(state))
 
     benchmark(run)
-

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,52 @@
+import dis
+import pytest
+from atom.api import Float, Int, Str, List, Bool, Dict
+from atomdb.base import Model
+
+state = dict(
+    title="This is a test",
+    desc="""Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+    sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+    Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+    nisi ut aliquip ex ea commodo consequat.
+    Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+    """,
+    enabled=True,
+    rating=8.3,
+    tags=["electronics", "laptop"],
+    meta={"views": 0},
+)
+
+
+class Product(Model):
+    title = Str()
+    desc = Str()
+    enabled = Bool()
+    rating = Float()
+    tags = List(str)
+    meta = Dict()
+
+
+def test_serialize(benchmark):
+    product = Product(
+        title="This is a test",
+        desc="""Lorem ipsum dolor sit amet, consectetur adipiscing elit,
+        sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+        Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris
+        nisi ut aliquip ex ea commodo consequat.
+        Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+        """,
+        enabled=True,
+        rating=8.3,
+        tags=["electronics", "laptop"],
+        meta={"views": 0},
+    )
+    benchmark(product.__getstate__)
+
+
+def test_restore(benchmark, event_loop):
+    def run():
+        event_loop.run_until_complete(Product.restore(state))
+
+    benchmark(run)
+

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,7 +1,10 @@
 import dis
 import pytest
-from atom.api import Float, Int, Str, List, Bool, Dict
+from datetime import datetime
+from atom.api import Float, Int, Str, List, Bool, Dict, Typed
 from atomdb.base import Model
+
+NOW = datetime.now()
 
 state = dict(
     title="This is a test",
@@ -13,6 +16,7 @@ state = dict(
     """,
     enabled=True,
     rating=8.3,
+    datetime=NOW.timestamp(),
     tags=["electronics", "laptop"],
     meta={"views": 0},
 )
@@ -25,6 +29,10 @@ class Product(Model):
     rating = Float()
     tags = List(str)
     meta = Dict()
+    created = Typed(datetime, factory=datetime.now).tag(
+        flatten=lambda v, scope: v.timestamp() if v else None,
+        unflatten=lambda v, scope: datetime.fromtimestamp(v) if v else None,
+    )
 
 
 @pytest.mark.benchmark(group="base")
@@ -39,6 +47,7 @@ def test_serialize(benchmark):
         """,
         enabled=True,
         rating=8.3,
+        created=NOW,
         tags=["electronics", "laptop"],
         meta={"views": 0},
     )

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -27,6 +27,7 @@ class Product(Model):
     meta = Dict()
 
 
+@pytest.mark.benchmark(group="base")
 def test_serialize(benchmark):
     product = Product(
         title="This is a test",
@@ -44,6 +45,7 @@ def test_serialize(benchmark):
     benchmark(product.__getstate__)
 
 
+@pytest.mark.benchmark(group="base")
 def test_restore(benchmark, event_loop):
     def run():
         event_loop.run_until_complete(Product.restore(state))

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -90,6 +90,7 @@ async def test_json_list():
     now = datetime.now()
     obj = Page(files=[f1, f2], created=now)
     state = obj.__getstate__()
+    assert isinstance(state['created'], float)  # Make sure conversion occurred
     data = json.dumps(state)
     r = await Page.restore(json.loads(data))
     assert r.created == now

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -32,7 +32,8 @@ class Page(JSONModel):
     files = List(File)
     created = Instance(datetime).tag(
         flatten=lambda d, scope: d.timestamp(),
-        unflatten=lambda v, scope: datetime.fromtimestamp(v) if v else None)
+        unflatten=lambda v, scope: datetime.fromtimestamp(v) if v else None,
+    )
 
 
 class Tree(JSONModel):
@@ -90,7 +91,7 @@ async def test_json_list():
     now = datetime.now()
     obj = Page(files=[f1, f2], created=now)
     state = obj.__getstate__()
-    assert isinstance(state['created'], float)  # Make sure conversion occurred
+    assert isinstance(state["created"], float)  # Make sure conversion occurred
     data = json.dumps(state)
     r = await Page.restore(json.loads(data))
     assert r.created == now

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -30,6 +30,9 @@ class File(JSONModel):
 
 class Page(JSONModel):
     files = List(File)
+    created = Instance(datetime).tag(
+        flatten=lambda d, scope: d.timestamp(),
+        unflatten=lambda v, scope: datetime.fromtimestamp(v) if v else None)
 
 
 class Tree(JSONModel):
@@ -84,10 +87,12 @@ async def test_json_bytes():
 async def test_json_list():
     f1 = File(name="test.png", data=b"abc")
     f2 = File(name="blueberry.jpg", data=b"123")
-    obj = Page(files=[f1, f2])
+    now = datetime.now()
+    obj = Page(files=[f1, f2], created=now)
     state = obj.__getstate__()
     data = json.dumps(state)
     r = await Page.restore(json.loads(data))
+    assert r.created == now
     assert len(r.files) == 2
     assert r.files[0].name == f1.name and r.files[0].data == f1.data
     assert r.files[1].name == f2.name and r.files[1].data == f2.data

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -113,7 +113,7 @@ class Image(SQLModel):
     data = Instance(bytes).tag(nullable=True)
 
     # Maps to sa.ARRAY, must include the item_type tag
-    size = Tuple(int).tag(nullable=True)
+    # size = Tuple(int).tag(nullable=True)
 
     #: Maps to sa.JSON
     info = Instance(ImageInfo, ())
@@ -1265,15 +1265,16 @@ def test_abstract_tables():
     CustomUser3.objects
 
 
+@pytest.mark.benchmark(group="sql")
 def test_benchmark(db, event_loop, benchmark):
     event_loop.run_until_complete(reset_tables(Image))
 
-    for i in range(1000):
+    for i in range(10):
         event_loop.run_until_complete(Image.objects.create(
             name=f"Image {i}",
             path=f"/media/some/path/{i}",
             alpha=i % 255,
-            size=(320, 240),
+            #size=(320, 240),
             data=b'12345678',
             metadata={"tag": "sunset"},
         ))

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -28,8 +28,7 @@ try:
     else:
         from psycopg2.errors import UniqueViolation as IntegrityError
 except ImportError as e:
-    raise
-    # pytest.skip("aiomysql and aiopg not available", allow_module_level=True)
+    pytest.skip("aiomysql and aiopg not available", allow_module_level=True)
 
 IS_MYSQL = DATABASE_URL.startswith("mysql")
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1268,7 +1268,7 @@ def test_abstract_tables():
 def test_benchmark(db, event_loop, benchmark):
     event_loop.run_until_complete(reset_tables(Image))
 
-    for i in range(10):
+    for i in range(1000):
         event_loop.run_until_complete(Image.objects.create(
             name=f"Image {i}",
             path=f"/media/some/path/{i}",


### PR DESCRIPTION
Instead of doing inspection on the members with every call to getstate/restorestate this generates an "inlined" function specific to the class.  WIP as this still needs more testing and implemented for the SQLModel.

This leads to about a 2x improvement for getstate and and about a 20% overall gain in pydantics benchmark.

Benchmarks from pydantic's test case (with atomdb added here https://github.com/frmdstryr/pydantic/tree/add-atom-db-benchmark)
```
testing pydantic, atom, attrs + cattrs, valideer, 5 times each
          pydantic (1/5) time=0.369s, success=47.95%
          pydantic (2/5) time=0.367s, success=47.95%
          pydantic (3/5) time=0.370s, success=47.95%
          pydantic (4/5) time=0.388s, success=47.95%
          pydantic (5/5) time=0.395s, success=47.95%
          pydantic best=0.367s, avg=0.378s, stdev=0.013s

              atom (1/5) time=0.309s, success=47.95%
              atom (2/5) time=0.289s, success=47.95%
              atom (3/5) time=0.293s, success=47.95%
              atom (4/5) time=0.296s, success=47.95%
              atom (5/5) time=0.306s, success=47.95%
              atom best=0.289s, avg=0.299s, stdev=0.009s

    attrs + cattrs (1/5) time=0.297s, success=47.95%
    attrs + cattrs (2/5) time=0.298s, success=47.95%
    attrs + cattrs (3/5) time=0.298s, success=47.95%
    attrs + cattrs (4/5) time=0.300s, success=47.95%
    attrs + cattrs (5/5) time=0.300s, success=47.95%
    attrs + cattrs best=0.297s, avg=0.299s, stdev=0.001s

          valideer (1/5) time=0.397s, success=47.95%
          valideer (2/5) time=0.417s, success=47.95%
          valideer (3/5) time=0.408s, success=47.95%
          valideer (4/5) time=0.828s, success=47.95%
          valideer (5/5) time=0.484s, success=47.95%
          valideer best=0.397s, avg=0.507s, stdev=0.183s

          pydantic best=61.173μs/iter avg=63.000μs/iter stdev=2.125μs/iter version=1.9.0
              atom best=48.121μs/iter avg=49.765μs/iter stdev=1.433μs/iter version=0.7.0
    attrs + cattrs best=49.576μs/iter avg=49.795μs/iter stdev=0.195μs/iter version=21.4.0
          valideer best=66.176μs/iter avg=84.462μs/iter stdev=30.477μs/iter version=0.4.2


```